### PR TITLE
Added new recipe for odin-control and dependencies

### DIFF
--- a/design/os/petalinux-custom/project-spec/meta-user/conf/user-rootfsconfig
+++ b/design/os/petalinux-custom/project-spec/meta-user/conf/user-rootfsconfig
@@ -1,5 +1,7 @@
 #Note: Mention Each package in individual line
 #These packages will get added into rootfs menu entry
 
-CONFIG_gpio-demo
-CONFIG_peekpoke
+#CONFIG_gpio-demo
+#CONFIG_peekpoke
+
+CONFIG_odin-control

--- a/design/os/petalinux-custom/project-spec/meta-user/recipes-apps/odin-control/files/fix-non-required-dependencies.patch
+++ b/design/os/petalinux-custom/project-spec/meta-user/recipes-apps/odin-control/files/fix-non-required-dependencies.patch
@@ -1,0 +1,16 @@
+diff --git a/setup.py b/setup.py
+index 0d442e6..ef50e48 100644
+--- a/setup.py
++++ b/setup.py
+@@ -3,10 +3,7 @@ from setuptools import setup, find_packages
+ import versioneer
+ 
+ install_requires = [
+-    'tornado>=4.3',
+-    'pyzmq>=17.0',
+-    'future',
+-    'psutil>=5.0',
++    'tornado>=4.3' 
+ ]
+ 
+ if sys.version_info[0] == 2:

--- a/design/os/petalinux-custom/project-spec/meta-user/recipes-apps/odin-control/odin-control.bb
+++ b/design/os/petalinux-custom/project-spec/meta-user/recipes-apps/odin-control/odin-control.bb
@@ -1,0 +1,19 @@
+SUMMARY = "This is a recipe to build odin-control on PetaLinux"
+
+# RDEPENDS specifies packages that are required at runtime on the host, as well as for build.
+RDEPENDS_${PN} += "python3-tornado (>=4.3)"
+RDEPENDS_${PN} += "python3-setuptools"
+RDEPENDS_${PN} += "python3-fcntl"
+
+SRC_URI = "git://github.com/odin-detector/odin-control.git \
+		file://fix-non-required-dependencies.patch"
+SRCREV = "1.0.0"
+
+# This has to be in the format expected in Yocto's license list...
+LICENSE = "Apachev2"
+# Get this value by running md5sum on the license file
+LIC_FILES_CHKSUM = "file://LICENSE;md5=e3fc50a88d0a364313df4b21ef20c29e"
+
+inherit setuptools3
+
+S = "${WORKDIR}/git/"


### PR DESCRIPTION
odin-control has been added to build from tag 1.0.0 from odin-detector.

To build properly, it needs some of the dependencies (future, pyzmq, psutil)
removed since they are not directly required by ODIN. They can be added at
a later date if required as custom recipes. They have been removed for now
from settings.py using a patch applied in the new odin-control recipe.

Resolves #3 