### PR TITLE
Add ssh authorized_keys persistence in mtd flash

### DIFF
--- a/design/os/petalinux-custom/project-spec/meta-user/recipes-apps/loki/files/config-default.conf
+++ b/design/os/petalinux-custom/project-spec/meta-user/recipes-apps/loki/files/config-default.conf
@@ -33,6 +33,11 @@ conf_NETWORK_OVERRIDE_ENABLE=0
 conf_NETWORK_STATIC_IP_ENABLE=0
 conf_NETWORK_STATIC_IP=''
 
+# Set to 0 to only use ssh keys that have been included in the image rather than those persistently held
+# in flash. If set 0, any keys added to /home/loki/.ssh/authorized_keys will be lost. If set 1, the flash
+# copy of .ssh will be bind mounted over the image's version (with any unique keys in the image duplicated).
+conf_PERSISTENT_SSH_AUTH=1
+
 # If enabled, the initial setup script will be run before any of the resources specified in this file
 # are accessed. It can therefore be used to set up network mounts where these resources might be
 # located, as well as perform any required arbitrary setup tasks that might be needed to ensure

--- a/design/os/petalinux-custom/project-spec/meta-user/recipes-apps/loki/loki-config.bb
+++ b/design/os/petalinux-custom/project-spec/meta-user/recipes-apps/loki/loki-config.bb
@@ -1,5 +1,7 @@
 SUMMARY = "Installer for generic LOKI setup script, which facilitates the configuration of a non-volatile debug setup."
 
+RDEPENDS_${PN} += "loki-config"
+
 # Repo URL.
 SRC_URI = "file://loki-config.sh \
     file://config-default.conf \


### PR DESCRIPTION
By default, the .ssh directory for the loki user is now mounted from the flash partition, meaning
that keys added to authorized_keys will remain persistent through both device reboots and image
updates. Since it is possible that default keys may be added to the image in the future, any keys
present in the image's default .ssh directory for loki will be copied into the flash partition's
copy automatically.

Additionally, there is a new configuration flag in the external config file that allows this
behaviour to be disabled, relying only on the image's .ssh directory. To stop ssh persistence,
simply set conf_PERSISTENT_SSH_AUTH to 0.