### PR TITLE
General LOKI build improvements

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -2,13 +2,16 @@
 
 SHELL := /bin/bash
 
-.PHONY: all mostlyclean clean hardware software os
+.PHONY: all mostlyclean clean hardware software os project
 
 LOKI_ROOT_ABS = @abs_top_builddir@
 HWSW_PATH=${LOKI_ROOT_ABS}/design/
 OS_PATH=@os_path@
 
 all: os
+
+project:
+	$(MAKE) -C ${HWSW_PATH} project
 
 hardware:
 	$(MAKE) -C ${HWSW_PATH} hardware

--- a/design/Makefile.in
+++ b/design/Makefile.in
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 
-.PHONY: hardware software all os mostlyclean clean distclean clobber export_bd_tcl platform_configure
+.PHONY: hardware software all os mostlyclean clean distclean clobber export_bd_tcl platform_configure project
 
 VIVADO_PROJ_PATH = vivado
 
@@ -41,6 +41,7 @@ ${VIVADO_PROJ_PATH}: .platform_configured
 
 	# Update timestamp
 	touch ${VIVADO_PROJ_PATH}
+project: ${VIVADO_PROJ_PATH} ;
 
 # Up-to-date TCL files are exported from the existing Vivado design
 export_bd_tcl:

--- a/os/petalinux-custom/project-spec/meta-user/classes/odin-control-instance.bbclass
+++ b/os/petalinux-custom/project-spec/meta-user/classes/odin-control-instance.bbclass
@@ -88,10 +88,11 @@ do_install_append() {
     install -d ${D}${base_prefix}${LOKI_RESOURCES_INSTALL_PATH}
 
 	# gnu install does not work well for recursive directories, so copy recursively the standardised
-    # paths. These should be defined in the application code.
-    copy_resource_protected '${REPO_STATIC_PATH}' '${LOKI_STATIC_DESTINATION}'
-    copy_resource_protected '${REPO_SEQUENCES_PATH}' '${LOKI_SEQUENCES_DESTINATION}'
-    copy_resource_protected '${REPO_CONFIG_PATH}' '${LOKI_CONFIG_DESTINATION}'
+    # paths. These should be defined in the application code. If one of these is not in use, just don't
+    # define it in the application recipe; it will be ignored.
+    [ ! -z ${REPO_STATIC_PATH} ] && copy_resource_protected '${REPO_STATIC_PATH}' '${LOKI_STATIC_DESTINATION}'
+    [ ! -z ${REPO_SEQUENCES_PATH} ] && copy_resource_protected '${REPO_SEQUENCES_PATH}' '${LOKI_SEQUENCES_DESTINATION}'
+    [ ! -z ${REPO_CONFIG_PATH} ] && copy_resource_protected '${REPO_CONFIG_PATH}' '${LOKI_CONFIG_DESTINATION}'
 
     # Create a loki-writeable directory
     loki_mkdir 'outputs'


### PR DESCRIPTION
These improvements have come about as we begin to investigate needing to alter the PL for different projects. However these initial changes are nothing to do with the PL, and therefore should benefit the main branch on other projects, when merged.

General summary:
- The user can now run `make project`, which will create the Vivado project without then building it. This is useful if you intend to start altering the block design.
- The pin handler for LOKI software control of GPIO lines now supports more than one `gpiochip` (from `libgpiod`), as it was discovered that adding additional GPIO buses creates new chips. This is backwards compatible, and a default bus will be assumed if not specified with pins (can be overridden).
- There is no longer a requirement to supply any / all of the static path, sequences path, and configuration file for odin instances when creating a recipe that is an odin-control instance. Whatever is included will be built into the image.