### PR TITLE
Hotfix - broken SSH key generation

### DIFF
--- a/os/petalinux-custom/project-spec/meta-user/recipes-core/dropbear/dropbear/dropbearkey.service
+++ b/os/petalinux-custom/project-spec/meta-user/recipes-core/dropbear/dropbear/dropbearkey.service
@@ -8,8 +8,16 @@ Environment="DROPBEAR_RSAKEY_DIR=/etc/dropbear"
 EnvironmentFile=-/etc/default/dropbear
 Type=oneshot
 ExecStart=/bin/mkdir -p ${DROPBEAR_RSAKEY_DIR}
+
 ExecStart=/bin/mkdir -p /mnt/emmc/dropbear
-ExecStart=/usr/sbin/dropbearkey -t rsa -f /tmp/RSA_HOST_KEY ${DROPBEAR_RSAKEY_ARGS} ; cp /tmp/RSAKEY ${DROPBEAR_RSAKEY}
-ExecStart=/usr/sbin/dropbearkey -t ecdsa -f /tmp/ECDSA_HOST_KEY ${DROPBEAR_ECDSAKEY_ARGS} ; cp /tmp/ECDSAKEY ${DROPBEAR_ECDSAKEY}
+
+ExecStart=/bin/bash -c 'rm -f /tmp/{RSA_HOST_KEY,ECDSA_HOST_KEY}'
+
+ExecStart=/usr/sbin/dropbearkey -t rsa -f /tmp/RSA_HOST_KEY ${DROPBEAR_RSAKEY_ARGS}
+ExecStart=/bin/bash -c 'cp /tmp/RSA_HOST_KEY ${DROPBEAR_RSAKEY}'
+
+ExecStart=/usr/sbin/dropbearkey -t ecdsa -f /tmp/ECDSA_HOST_KEY ${DROPBEAR_ECDSAKEY_ARGS}
+ExecStart=/bin/bash -c 'cp /tmp/ECDSA_HOST_KEY ${DROPBEAR_ECDSAKEY}'
+
 RemainAfterExit=yes
 Nice=10


### PR DESCRIPTION
Location was incorrectly specified for copy, so new keys failed to be stored